### PR TITLE
Remove malloc functions from scratch_impl.h using a patch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,13 +68,19 @@ jobs:
 
   Tests:
     name: Tests
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
           - 1.29.0
           - beta
           - stable
+        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/secp256k1-zkp-sys/depend/scratch_impl.h.patch
+++ b/secp256k1-zkp-sys/depend/scratch_impl.h.patch
@@ -1,0 +1,26 @@
+13,37d12
+< static secp256k1_scratch* secp256k1_scratch_create(const secp256k1_callback* error_callback, size_t size) {
+<     const size_t base_alloc = ROUND_TO_ALIGN(sizeof(secp256k1_scratch));
+<     void *alloc = checked_malloc(error_callback, base_alloc + size);
+<     secp256k1_scratch* ret = (secp256k1_scratch *)alloc;
+<     if (ret != NULL) {
+<         memset(ret, 0, sizeof(*ret));
+<         memcpy(ret->magic, "scratch", 8);
+<         ret->data = (void *) ((char *) alloc + base_alloc);
+<         ret->max_size = size;
+<     }
+<     return ret;
+< }
+< 
+< static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, secp256k1_scratch* scratch) {
+<     if (scratch != NULL) {
+<         VERIFY_CHECK(scratch->alloc_size == 0); /* all checkpoints should be applied */
+<         if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
+<             secp256k1_callback_call(error_callback, "invalid scratch space");
+<             return;
+<         }
+<         memset(scratch->magic, 0, sizeof(scratch->magic));
+<         free(scratch);
+<     }
+< }
+< 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/scratch_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/scratch_impl.h
@@ -10,31 +10,6 @@
 #include "util.h"
 #include "scratch.h"
 
-static rustsecp256k1zkp_v0_1_0_scratch* rustsecp256k1zkp_v0_1_0_scratch_create(const rustsecp256k1zkp_v0_1_0_callback* error_callback, size_t size) {
-    const size_t base_alloc = ROUND_TO_ALIGN(sizeof(rustsecp256k1zkp_v0_1_0_scratch));
-    void *alloc = checked_malloc(error_callback, base_alloc + size);
-    rustsecp256k1zkp_v0_1_0_scratch* ret = (rustsecp256k1zkp_v0_1_0_scratch *)alloc;
-    if (ret != NULL) {
-        memset(ret, 0, sizeof(*ret));
-        memcpy(ret->magic, "scratch", 8);
-        ret->data = (void *) ((char *) alloc + base_alloc);
-        ret->max_size = size;
-    }
-    return ret;
-}
-
-static void rustsecp256k1zkp_v0_1_0_scratch_destroy(const rustsecp256k1zkp_v0_1_0_callback* error_callback, rustsecp256k1zkp_v0_1_0_scratch* scratch) {
-    if (scratch != NULL) {
-        VERIFY_CHECK(scratch->alloc_size == 0); /* all checkpoints should be applied */
-        if (rustsecp256k1zkp_v0_1_0_memcmp_var(scratch->magic, "scratch", 8) != 0) {
-            rustsecp256k1zkp_v0_1_0_callback_call(error_callback, "invalid scratch space");
-            return;
-        }
-        memset(scratch->magic, 0, sizeof(scratch->magic));
-        free(scratch);
-    }
-}
-
 static size_t rustsecp256k1zkp_v0_1_0_scratch_checkpoint(const rustsecp256k1zkp_v0_1_0_callback* error_callback, const rustsecp256k1zkp_v0_1_0_scratch* scratch) {
     if (rustsecp256k1zkp_v0_1_0_memcmp_var(scratch->magic, "scratch", 8) != 0) {
         rustsecp256k1zkp_v0_1_0_callback_call(error_callback, "invalid scratch space");

--- a/secp256k1-zkp-sys/vendor-libsecp.sh
+++ b/secp256k1-zkp-sys/vendor-libsecp.sh
@@ -42,6 +42,7 @@ echo "$HEAD" >> ./secp256k1-HEAD-revision.txt
 # To compensate, the secp_context_create and _destroy methods are redefined in Rust.
 patch "$DIR/include/secp256k1.h" "./secp256k1.h.patch"
 patch "$DIR/src/secp256k1.c" "./secp256k1.c.patch"
+patch "$DIR/src/scratch_impl.h" "./scratch_impl.h.patch"
 patch "$DIR/src/util.h" "./util.h.patch"
 git apply "./surjection_impl.h.patch"
 git apply "./surjection_main_impl.h.patch"


### PR DESCRIPTION
This PR removes functions which uses `checked_malloc` (which uses `malloc` underthehood). This was a problem on MacOS because the compiler was correctly complaining that these functions were not declared. 

Apparently this was not an issue on ubuntu and hence I also updated the CI to build on MacOS. 

Running the wasm tests on MacOS does not work atm. This problem seems to be related https://github.com/rust-bitcoin/rust-secp256k1/pull/254