### PR TITLE
Cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	cargo test
+	cargo test --features "global-context"
 
 build:
 	cargo build

--- a/secp256k1-zkp-sys/Cargo.toml
+++ b/secp256k1-zkp-sys/Cargo.toml
@@ -17,7 +17,7 @@ links = "rustsecp256k1zkp_v0_1_0"
 
 # Should make docs.rs show all functions, even those behind non-default features
 [package.metadata.docs.rs]
-features = [ "recovery", "endomorphism", "lowmemory" ]
+features = [ "recovery", "lowmemory" ]
 
 [build-dependencies]
 cc = "1.0.28"

--- a/secp256k1-zkp-sys/build.rs
+++ b/secp256k1-zkp-sys/build.rs
@@ -38,7 +38,6 @@ fn main() {
                .include("depend/secp256k1/src")
                .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
                .define("SECP256K1_BUILD", Some("1"))
-               .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_SURJECTIONPROOF", Some("1"))
                .define("ENABLE_MODULE_GENERATOR", Some("1"))
                .define("ENABLE_MODULE_RANGEPROOF", Some("1"))
@@ -54,8 +53,6 @@ fn main() {
         base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
     }
     base_config.define("USE_EXTERNAL_DEFAULT_CALLBACKS", Some("1"));
-    #[cfg(feature = "recovery")]
-    base_config.define("ENABLE_MODULE_RECOVERY", Some("1"));
 
     if let Ok(target_endian) = env::var("CARGO_CFG_TARGET_ENDIAN") {
         if target_endian == "big" {

--- a/src/zkp/rangeproof.rs
+++ b/src/zkp/rangeproof.rs
@@ -375,7 +375,7 @@ mod tests {
             commitment_secrets.value_blinding_factor
         );
 
-        // TODO: File bug with upstream: message length is not set correctly
         assert!(opening.message.starts_with(message));
+        assert!(opening.message.ends_with(&vec![0; opening.message.len() - message.len()]));
     }
 }


### PR DESCRIPTION
enjoyed reading this lib. It's a really good start for hopefully more -zkp stuff to come. I have a few questions just to clear up my understanding:

- Why can't the rangeproof be allocated on the stack as a 5134 element c_uchar array?
- Is there a particular reason why the ffi::PublicKey type is used instead of defining some ffi::Generator?
- Is there a reason why `compute_adaptive_blinding_factor` doesn't return `CommitmentSecrets` directly?
- wasm-sysroot/stdio.h is different from rust-secp's, is that intentional?
